### PR TITLE
Added Github Actions CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,8 +6,7 @@ jobs:
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v2
-    - uses: microsoft/setup-msbuild@v1.0.2
     - name: Restore packages
-      run: msbuild src/LudusaviPlaynite.csproj /t:restore
+      run: dotnet restore src
     - name: Build
-      run: msbuild src/LudusaviPlaynite.csproj /t:build
+      run: dotnet build src

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,13 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  Build:
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+    - uses: microsoft/setup-msbuild@v1.0.2
+    - name: Restore packages
+      run: msbuild src/LudusaviPlaynite.csproj /t:restore
+    - name: Build
+      run: msbuild src/LudusaviPlaynite.csproj /t:build


### PR DESCRIPTION
Github provides free builds for open source projects. This is nice to have the green checkmark next to commits, but also to validate any future work on the project.

Example passing job here: https://github.com/scowalt/ludusavi-playnite/runs/1815839383?check_suite_focus=true