### PR TITLE
Support for playnite 9

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -1,7 +1,7 @@
 ﻿Id: mtkennerly.ludusavi
 Name: Ludusavi
 Author: Matthew T. Kennerly
-Version: 0.5.1
+Version: 0.6.0
 Module: LudusaviPlaynite.dll
 Type: GenericPlugin
 Icon: icon.png

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,8 @@
+AddonId: mtkennerly.ludusavi
+Packages:
+  - Version: 0.6.0
+    RequiredApiVersion: 6.0.0
+    ReleaseDate: 2021-09-07
+    PackageUrl: https://github.com/mtkennerly/ludusavi-playnite/releases/download/v0.6.0/ludusavi-playnite-v0.6.0.pext
+    Changelog:
+      - Playnite 9 support

--- a/src/LudusaviPlaynite.cs
+++ b/src/LudusaviPlaynite.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using Playnite.SDK;
 using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
+using Playnite.SDK.Events;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -15,7 +16,7 @@ using System.Windows.Controls;
 
 namespace LudusaviPlaynite
 {
-    public class LudusaviPlaynite : Plugin
+    public class LudusaviPlaynite : GenericPlugin
     {
         private static readonly ILogger logger = LogManager.GetLogger();
         public LudusaviPlayniteSettings settings { get; set; }
@@ -30,6 +31,10 @@ namespace LudusaviPlaynite
         {
             translator = new Translator(DetermineLanguage());
             settings = new LudusaviPlayniteSettings(this, translator);
+            Properties = new GenericPluginProperties
+            {
+                HasSettings = true
+            };
         }
 
         private Language DetermineLanguage()
@@ -42,7 +47,7 @@ namespace LudusaviPlaynite
             }
         }
 
-        public override List<MainMenuItem> GetMainMenuItems(GetMainMenuItemsArgs menuArgs)
+        public override IEnumerable<MainMenuItem> GetMainMenuItems(GetMainMenuItemsArgs menuArgs)
         {
             return new List<MainMenuItem>
             {
@@ -117,7 +122,7 @@ namespace LudusaviPlaynite
             };
         }
 
-        public override List<GameMenuItem> GetGameMenuItems(GetGameMenuItemsArgs menuArgs)
+        public override IEnumerable<GameMenuItem> GetGameMenuItems(GetGameMenuItemsArgs menuArgs)
         {
             return new List<GameMenuItem>
             {
@@ -156,24 +161,24 @@ namespace LudusaviPlaynite
             };
         }
 
-        public override void OnGameStopped(Game game, long elapsedSeconds)
+        public override void OnGameStopped(OnGameStoppedEventArgs arg)
         {
             playedSomething = true;
-            lastGamePlayed = game;
+            lastGamePlayed = arg.Game;
 
-            if (settings.DoBackupOnGameStopped && !ShouldSkipGame(game) && (IsOnPc(game) || !settings.OnlyBackupOnGameStoppedIfPc))
+            if (settings.DoBackupOnGameStopped && !ShouldSkipGame(arg.Game) && (IsOnPc(arg.Game) || !settings.OnlyBackupOnGameStoppedIfPc))
             {
-                if (!settings.AskBackupOnGameStopped || UserConsents(translator.BackUpOneGame_Confirm(GetGameName(game), RequiresCustomEntry(game))))
+                if (!settings.AskBackupOnGameStopped || UserConsents(translator.BackUpOneGame_Confirm(GetGameName(arg.Game), RequiresCustomEntry(arg.Game))))
                 {
-                    Task.Run(() => BackUpOneGame(game));
+                    Task.Run(() => BackUpOneGame(arg.Game));
                 }
             }
 
-            if (settings.DoPlatformBackupOnNonPcGameStopped && !ShouldSkipGame(game) && !IsOnPc(game))
+            if (settings.DoPlatformBackupOnNonPcGameStopped && !ShouldSkipGame(arg.Game) && !IsOnPc(arg.Game))
             {
-                if (!settings.AskPlatformBackupOnNonPcGameStopped || UserConsents(translator.BackUpOneGame_Confirm(game.Platform.Name, true)))
+                if (!settings.AskPlatformBackupOnNonPcGameStopped || UserConsents(translator.BackUpOneGame_Confirm(arg.Game.Platforms[0].Name, true)))
                 {
-                    Task.Run(() => BackUpOneGame(game, new BackupCriteria { ByPlatform = true }));
+                    Task.Run(() => BackUpOneGame(arg.Game, new BackupCriteria { ByPlatform = true }));
                 }
             }
         }
@@ -322,14 +327,17 @@ namespace LudusaviPlaynite
 
         private bool ShouldSkipGame(Game game)
         {
-            return game.Tags != null && game.Tags.Any(x => x.Name == "ludusavi-skip");
+            return game.Tags != null
+                && game.Tags.Any(x => x.Name == "ludusavi-skip")
+                && game.Platforms.Count > 1;
         }
 
         string GetGameName(Game game)
         {
             if (!IsOnPc(game) && settings.AddSuffixForNonPcGameNames)
             {
-                return string.Format("{0}{1}", game.Name, settings.SuffixForNonPcGameNames.Replace("<platform>", game.Platform?.Name));
+                string platformName = game.Platforms[0].ToString();
+                return string.Format("{0}{1}", game.Name, settings.SuffixForNonPcGameNames.Replace("<platform>", platformName));
             }
             else
             {
@@ -339,12 +347,12 @@ namespace LudusaviPlaynite
 
         bool IsOnSteam(Game game)
         {
-            return game.Source?.Name == "Steam";
+            return game.Source.Name == "Steam";
         }
 
         bool IsOnPc(Game game)
         {
-            return game.Platform?.Name == "PC";
+            return game.Platforms[0].ToString() == "PC (Windows)";
         }
 
         bool RequiresCustomEntry(Game game)
@@ -360,7 +368,7 @@ namespace LudusaviPlaynite
         private void BackUpOneGame(Game game, BackupCriteria criteria)
         {
             pendingOperation = true;
-            var name = criteria.ByPlatform ? game.Platform.Name : GetGameName(game);
+            var name = criteria.ByPlatform ? game.Platforms[0].Name : GetGameName(game);
 
             var (code, response) = InvokeLudusavi(string.Format("backup --merge --try-update --path \"{0}\" \"{1}\"", settings.BackupPath, name));
             if (!criteria.ByPlatform)

--- a/src/LudusaviPlaynite.csproj
+++ b/src/LudusaviPlaynite.csproj
@@ -12,7 +12,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="WindowsBase" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
-    <PackageReference Include="PlayniteSDK" Version="5.4.0" />
+    <PackageReference Include="PlayniteSDK" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Updated for SDK changes in Playnite 9 (SDK 6.0.0)
- A game can now have multiple platforms. For now, just use the first platform and don't backup if there is more than one platform. The current platform backup system will likely need to be reworked, but seemed out of scope for this PR.